### PR TITLE
fix: retain browsing area size on expansion

### DIFF
--- a/chrome/userChrome.css
+++ b/chrome/userChrome.css
@@ -27,13 +27,13 @@
   display: none
 }
  
-#sidebar-box {
+#sidebar {
   transition: min-width 115ms linear var(--uc-autohide-sidebar-delay) !important;
   min-width: var(--uc-sidebar-width) !important;
   will-change: min-width;
 }
  
-#sidebar-box:hover {
+#sidebar-box:hover > .sidebar-browser.stack > #sidebar {
   min-width: var(--uc-sidebar-hover-width) !important;
   transition-delay: 0ms !important;
 }

--- a/chrome/userChrome.css
+++ b/chrome/userChrome.css
@@ -33,7 +33,7 @@
   will-change: min-width;
 }
  
-#sidebar-box:hover > .sidebar-browser.stack > #sidebar {
+#sidebar:hover {
   min-width: var(--uc-sidebar-hover-width) !important;
   transition-delay: 0ms !important;
 }


### PR DESCRIPTION
A couple of tweaks to the selectors seems to have fixed the issue of the browsing area size changing, on sidebar hover. Feel free to test to make sure it also works on your end.